### PR TITLE
laserlight: fix herp laser jittering due to it trying to target enemies

### DIFF
--- a/laserlight/module/laser.zsc
+++ b/laserlight/module/laser.zsc
@@ -245,7 +245,7 @@ class UaS_LaserLightModule : HDWeapon {
 			// }
 
 			double targetpitch = owner.pitch;
-			if (owner.target) {
+			if (!(owner is "HERPBot") && owner.target) {
 				targetpitch = owner.PitchTo(owner.target, zOfs: owner.height*heightfactor, targZOfs:owner.target.height/2);
 				//console.printf(""..targetpitch);
 			}

--- a/laserlight/module/laser.zsc
+++ b/laserlight/module/laser.zsc
@@ -245,6 +245,7 @@ class UaS_LaserLightModule : HDWeapon {
 			// }
 
 			double targetpitch = owner.pitch;
+			// HERPs are excluded because it makes their lasers wobble a lot
 			if (!(owner is "HERPBot") && owner.target) {
 				targetpitch = owner.PitchTo(owner.target, zOfs: owner.height*heightfactor, targZOfs:owner.target.height/2);
 				//console.printf(""..targetpitch);


### PR DESCRIPTION
For some reason, the HERP's laser freaks out when trying to pitch to a `target`
This PR just adds a check to exclude HERPs from the target pitch check, as it seems to work fine without it.
Should hopefully fix #225